### PR TITLE
FCM 초기 설정 및 스터디 만들기 화면 알림 권한 요청 구현

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,2 +1,3 @@
 /build
 google-services.json
+/src/main/assets/service-account.json

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,6 +21,7 @@ android {
         versionCode = 1
         versionName = "1.0"
         buildConfigField("String", "FIREBASE_BASE_URL", getProperty("FIREBASE_BASE_URL"))
+        buildConfigField("String", "FIREBASE_SENDER_ID", getProperty("FIREBASE_SENDER_ID"))
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -46,6 +47,9 @@ android {
         buildConfig = true
         dataBinding = true
     }
+    packaging {
+        resources.excludes.add("META-INF/*")
+    }
 }
 
 fun getProperty(key: String): String {
@@ -62,6 +66,9 @@ dependencies {
     implementation("com.google.firebase:firebase-analytics")
     implementation("com.google.firebase:firebase-auth")
     implementation("com.google.firebase:firebase-storage")
+    implementation("com.google.firebase:firebase-messaging")
+    implementation("com.google.firebase:firebase-messaging-directboot")
+    implementation("com.google.auth:google-auth-library-oauth2-http:1.23.0")
     implementation("androidx.core:core-splashscreen:1.0.1")
     implementation("androidx.navigation:navigation-fragment-ktx:2.7.6")
     implementation("androidx.navigation:navigation-ui-ktx:2.7.6")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,5 +26,20 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <service
+            android:name=".MyFirebaseMessagingService"
+            android:directBootAware="true"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_icon"
+            android:resource="@drawable/ic_launcher_foreground" />
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_channel_id"
+            android:value="@string/default_notification_channel_id" />
     </application>
 </manifest>

--- a/app/src/main/java/com/sesac/developer_study_platform/MyFirebaseMessagingService.kt
+++ b/app/src/main/java/com/sesac/developer_study_platform/MyFirebaseMessagingService.kt
@@ -1,0 +1,38 @@
+package com.sesac.developer_study_platform
+
+import android.util.Log
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+import com.sesac.developer_study_platform.data.source.local.FcmTokenRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class MyFirebaseMessagingService : FirebaseMessagingService() {
+
+    private val fcmTokenRepository = FcmTokenRepository(this)
+
+    override fun onNewToken(token: String) {
+        super.onNewToken(token)
+
+        CoroutineScope(Dispatchers.IO).launch {
+            fcmTokenRepository.setToken(token)
+        }
+    }
+
+    override fun onMessageReceived(remoteMessage: RemoteMessage) {
+        // TODO(developer): Handle FCM messages here.
+        // Not getting messages here? See why this may be: https://goo.gl/39bRNJ
+        Log.d("fcm", "From: ${remoteMessage.from}")
+
+        // Check if message contains a data payload.
+        if (remoteMessage.data.isNotEmpty()) {
+            Log.d("fcm", "Message data payload: ${remoteMessage.data}")
+        }
+
+        // Check if message contains a notification payload.
+        remoteMessage.notification?.let {
+            Log.d("fcm", "Message Notification Body: ${it.body}")
+        }
+    }
+}

--- a/app/src/main/java/com/sesac/developer_study_platform/StudyApplication.kt
+++ b/app/src/main/java/com/sesac/developer_study_platform/StudyApplication.kt
@@ -7,6 +7,7 @@ import com.sesac.developer_study_platform.data.source.local.BookmarkDao
 import com.sesac.developer_study_platform.data.source.local.BookmarkRepository
 import com.sesac.developer_study_platform.data.source.local.MyStudyDao
 import com.sesac.developer_study_platform.data.source.local.MyStudyRepository
+import com.sesac.developer_study_platform.data.source.remote.FcmRepository
 import com.sesac.developer_study_platform.data.source.remote.GithubRepository
 import com.sesac.developer_study_platform.data.source.remote.StudyRepository
 
@@ -25,6 +26,7 @@ class StudyApplication : Application() {
         bookmarkRepository = BookmarkRepository()
         myStudyDao = db.myStudyDao()
         myStudyRepository = MyStudyRepository()
+        fcmRepository = FcmRepository(this)
     }
 
     override fun onTerminate() {
@@ -39,5 +41,6 @@ class StudyApplication : Application() {
         lateinit var bookmarkRepository: BookmarkRepository
         lateinit var myStudyDao: MyStudyDao
         lateinit var myStudyRepository: MyStudyRepository
+        lateinit var fcmRepository: FcmRepository
     }
 }

--- a/app/src/main/java/com/sesac/developer_study_platform/data/FcmMessage.kt
+++ b/app/src/main/java/com/sesac/developer_study_platform/data/FcmMessage.kt
@@ -1,0 +1,14 @@
+package com.sesac.developer_study_platform.data
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FcmMessage(
+    val message: FcmMessageData,
+)
+
+@Serializable
+data class FcmMessageData(
+    val token: String = "",
+    val data: Map<String, String> = mapOf(),
+)

--- a/app/src/main/java/com/sesac/developer_study_platform/data/StudyGroup.kt
+++ b/app/src/main/java/com/sesac/developer_study_platform/data/StudyGroup.kt
@@ -1,0 +1,12 @@
+package com.sesac.developer_study_platform.data
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class StudyGroup(
+    val operation: String = "",
+    @SerialName("notification_key_name") val notificationKeyName: String = "",
+    @SerialName("registration_ids") val registrationIdList: List<String> = listOf(),
+    @SerialName("notification_key") val notificationKey: String = "",
+)

--- a/app/src/main/java/com/sesac/developer_study_platform/data/source/local/FcmTokenRepository.kt
+++ b/app/src/main/java/com/sesac/developer_study_platform/data/source/local/FcmTokenRepository.kt
@@ -1,0 +1,34 @@
+package com.sesac.developer_study_platform.data.source.local
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+private const val FCM_TOKEN_DATASTORE = "fcm_token_datastore"
+
+val Context.fcmTokenDataStore: DataStore<Preferences> by preferencesDataStore(FCM_TOKEN_DATASTORE)
+
+class FcmTokenRepository(private val context: Context) {
+
+    suspend fun setToken(token: String) {
+        context.fcmTokenDataStore.edit { preferences ->
+            preferences[FCM_TOKEN_KEY] = token
+        }
+    }
+
+    fun getToken(): Flow<String> {
+        return context.fcmTokenDataStore.data
+            .map { preferences ->
+                preferences[FCM_TOKEN_KEY] ?: ""
+            }
+    }
+
+    companion object {
+        private val FCM_TOKEN_KEY = stringPreferencesKey("fcm_token")
+    }
+}

--- a/app/src/main/java/com/sesac/developer_study_platform/data/source/remote/FcmRepository.kt
+++ b/app/src/main/java/com/sesac/developer_study_platform/data/source/remote/FcmRepository.kt
@@ -1,0 +1,18 @@
+package com.sesac.developer_study_platform.data.source.remote
+
+import android.content.Context
+import com.sesac.developer_study_platform.data.FcmMessage
+import com.sesac.developer_study_platform.data.StudyGroup
+
+class FcmRepository(context: Context) {
+
+    private val fcmService = FcmService.create(context)
+
+    suspend fun updateStudyGroup(studyGroup: StudyGroup): Map<String, String> {
+        return fcmService.updateStudyGroup(studyGroup)
+    }
+
+    suspend fun sendNotification(message: FcmMessage) {
+        fcmService.sendNotification(message)
+    }
+}

--- a/app/src/main/java/com/sesac/developer_study_platform/data/source/remote/FcmService.kt
+++ b/app/src/main/java/com/sesac/developer_study_platform/data/source/remote/FcmService.kt
@@ -1,0 +1,63 @@
+package com.sesac.developer_study_platform.data.source.remote
+
+import android.content.Context
+import com.google.auth.oauth2.GoogleCredentials
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import com.sesac.developer_study_platform.BuildConfig
+import com.sesac.developer_study_platform.data.FcmMessage
+import com.sesac.developer_study_platform.data.StudyGroup
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface FcmService {
+
+    @POST("fcm/notification")
+    suspend fun updateStudyGroup(
+        @Body studyGroup: StudyGroup
+    ): Map<String, String>
+
+    @POST("v1/projects/developer-study-platform/messages:send")
+    suspend fun sendNotification(
+        @Body message: FcmMessage
+    )
+
+    companion object {
+        private const val BASE_URL = "https://fcm.googleapis.com"
+        private const val SCOPES = "https://www.googleapis.com/auth/firebase.messaging"
+        private val contentType = "application/json".toMediaType()
+        private val jsonConfig = Json { ignoreUnknownKeys = true }
+
+        private fun getClient(context: Context): OkHttpClient {
+            return OkHttpClient.Builder().addInterceptor { chain ->
+                val builder = chain.request().newBuilder().apply {
+                    addHeader("access_token_auth", "true")
+                    addHeader("Authorization", "Bearer ${getAccessToken(context)}")
+                    addHeader("project_id", BuildConfig.FIREBASE_SENDER_ID)
+                }
+                chain.proceed(builder.build())
+            }.build()
+        }
+
+        private fun getAccessToken(context: Context): String {
+            val inputStream = context.resources.assets.open("service-account.json")
+            val googleCredential = GoogleCredentials
+                .fromStream(inputStream)
+                .createScoped(listOf(SCOPES))
+            googleCredential.refresh()
+            return googleCredential.accessToken.tokenValue
+        }
+
+        fun create(context: Context): FcmService {
+            return Retrofit.Builder()
+                .baseUrl(BASE_URL)
+                .client(getClient(context))
+                .addConverterFactory(jsonConfig.asConverterFactory(contentType))
+                .build()
+                .create(FcmService::class.java)
+        }
+    }
+}

--- a/app/src/main/java/com/sesac/developer_study_platform/data/source/remote/StudyRepository.kt
+++ b/app/src/main/java/com/sesac/developer_study_platform/data/source/remote/StudyRepository.kt
@@ -90,6 +90,14 @@ class StudyRepository {
         studyService.deleteUserStudy(uid, sid)
     }
 
+    suspend fun addNotificationKey(sid: String, notificationKey: String) {
+        studyService.addNotificationKey(sid, notificationKey)
+    }
+
+    suspend fun getNotificationKey(sid: String): String {
+        return studyService.getNotificationKey(sid)
+    }
+
     fun getMessageList(sid: String): Flow<Map<String, Message>> = flow {
         while (true) {
             kotlin.runCatching {

--- a/app/src/main/java/com/sesac/developer_study_platform/data/source/remote/StudyRepository.kt
+++ b/app/src/main/java/com/sesac/developer_study_platform/data/source/remote/StudyRepository.kt
@@ -94,8 +94,12 @@ class StudyRepository {
         studyService.addNotificationKey(sid, notificationKey)
     }
 
-    suspend fun getNotificationKey(sid: String): String {
+    suspend fun getNotificationKey(sid: String): String? {
         return studyService.getNotificationKey(sid)
+    }
+
+    suspend fun addRegistrationId(sid: String, registrationId: String) {
+        studyService.addRegistrationId(sid, mapOf(registrationId to true))
     }
 
     fun getMessageList(sid: String): Flow<Map<String, Message>> = flow {

--- a/app/src/main/java/com/sesac/developer_study_platform/data/source/remote/StudyService.kt
+++ b/app/src/main/java/com/sesac/developer_study_platform/data/source/remote/StudyService.kt
@@ -159,7 +159,13 @@ interface StudyService {
     @GET("studies/{sid}/notificationKey.json")
     suspend fun getNotificationKey(
         @Path("sid") sid: String,
-    ): String
+    ): String?
+
+    @PATCH("studies/{sid}/registrationIds.json")
+    suspend fun addRegistrationId(
+        @Path("sid") sid: String,
+        @Body registrationId: Map<String, Boolean>
+    )
 
     companion object {
         private const val BASE_URL = BuildConfig.FIREBASE_BASE_URL

--- a/app/src/main/java/com/sesac/developer_study_platform/data/source/remote/StudyService.kt
+++ b/app/src/main/java/com/sesac/developer_study_platform/data/source/remote/StudyService.kt
@@ -150,6 +150,17 @@ interface StudyService {
         @Path("sid") sid: String
     )
 
+    @PUT("studies/{sid}/notificationKey.json")
+    suspend fun addNotificationKey(
+        @Path("sid") sid: String,
+        @Body notificationKey: String
+    )
+
+    @GET("studies/{sid}/notificationKey.json")
+    suspend fun getNotificationKey(
+        @Path("sid") sid: String,
+    ): String
+
     companion object {
         private const val BASE_URL = BuildConfig.FIREBASE_BASE_URL
         private val contentType = "application/json".toMediaType()

--- a/app/src/main/java/com/sesac/developer_study_platform/ui/detail/JoinStudyDialogFragment.kt
+++ b/app/src/main/java/com/sesac/developer_study_platform/ui/detail/JoinStudyDialogFragment.kt
@@ -1,10 +1,16 @@
 package com.sesac.developer_study_platform.ui.detail
 
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
+import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -12,14 +18,26 @@ import androidx.navigation.fragment.navArgs
 import com.sesac.developer_study_platform.EventObserver
 import com.sesac.developer_study_platform.R
 import com.sesac.developer_study_platform.data.UserStudy
+import com.sesac.developer_study_platform.data.source.local.FcmTokenRepository
 import com.sesac.developer_study_platform.databinding.DialogJoinStudyBinding
 
 class JoinStudyDialogFragment : DialogFragment() {
 
     private var _binding: DialogJoinStudyBinding? = null
     private val binding get() = _binding!!
-    private val viewModel by viewModels<JoinStudyDialogViewModel>()
+    private val viewModel by viewModels<JoinStudyDialogViewModel> {
+        JoinStudyDialogViewModel.create(FcmTokenRepository(requireContext()))
+    }
     private val args by navArgs<JoinStudyDialogFragmentArgs>()
+    private val requestPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
+            if (isGranted) {
+                updateStudyGroup()
+            } else {
+                Toast.makeText(context, getString(R.string.all_notification_info), Toast.LENGTH_SHORT).show()
+                viewModel.moveToMessage(args.study.sid)
+            }
+        }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -62,7 +80,7 @@ class JoinStudyDialogFragment : DialogFragment() {
             viewModel.addUserStudyEvent.observe(
                 viewLifecycleOwner,
                 EventObserver {
-                    viewModel.moveToMessage(args.study.sid)
+                    askNotificationPermission()
                 }
             )
         }
@@ -74,6 +92,39 @@ class JoinStudyDialogFragment : DialogFragment() {
             EventObserver {
                 val action = JoinStudyDialogFragmentDirections.actionJoinStudyDialogToMessage(it)
                 findNavController().navigate(action)
+            }
+        )
+    }
+
+    private fun askNotificationPermission() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            when {
+                ContextCompat.checkSelfPermission(
+                    requireContext(),
+                    Manifest.permission.POST_NOTIFICATIONS
+                ) == PackageManager.PERMISSION_GRANTED -> {
+                    updateStudyGroup()
+                }
+
+                shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS) -> {
+                    // TODO 권한 이유 다이얼로그
+                }
+
+                else -> {
+                    requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                }
+            }
+        } else {
+            updateStudyGroup()
+        }
+    }
+
+    private fun updateStudyGroup() {
+        viewModel.updateStudyGroup(args.study.sid)
+        viewModel.updateStudyGroupEvent.observe(
+            viewLifecycleOwner,
+            EventObserver {
+                viewModel.moveToMessage(args.study.sid)
             }
         )
     }

--- a/app/src/main/java/com/sesac/developer_study_platform/ui/message/MessageFragment.kt
+++ b/app/src/main/java/com/sesac/developer_study_platform/ui/message/MessageFragment.kt
@@ -74,7 +74,6 @@ class MessageFragment : Fragment() {
         binding.isNetworkConnected = isNetworkConnected(requireContext())
     }
 
-
     private fun setBackButton() {
         binding.toolbar.setNavigationOnClickListener {
             viewModel.moveToBack()

--- a/app/src/main/java/com/sesac/developer_study_platform/ui/studyform/StudyFormViewModel.kt
+++ b/app/src/main/java/com/sesac/developer_study_platform/ui/studyform/StudyFormViewModel.kt
@@ -1,0 +1,74 @@
+package com.sesac.developer_study_platform.ui.studyform
+
+import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.sesac.developer_study_platform.Event
+import com.sesac.developer_study_platform.StudyApplication.Companion.fcmRepository
+import com.sesac.developer_study_platform.StudyApplication.Companion.studyRepository
+import com.sesac.developer_study_platform.data.StudyGroup
+import com.sesac.developer_study_platform.data.source.local.FcmTokenRepository
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+
+class StudyFormViewModel(private val fcmTokenRepository: FcmTokenRepository) : ViewModel() {
+
+    private val _createNotificationKeyEvent: MutableLiveData<Event<Unit>> = MutableLiveData()
+    val createNotificationKeyEvent: LiveData<Event<Unit>> = _createNotificationKeyEvent
+
+    private val _moveToMessageEvent: MutableLiveData<Event<String>> = MutableLiveData()
+    val moveToMessageEvent: LiveData<Event<String>> = _moveToMessageEvent
+
+    fun createNotificationKey(sid: String) {
+        viewModelScope.launch {
+            val token = fcmTokenRepository.getToken().first()
+            kotlin.runCatching {
+                fcmRepository.updateStudyGroup(StudyGroup("create", sid, listOf(token)))
+            }.onSuccess {
+                addNotificationKey(sid, it.values.first())
+            }.onFailure {
+                Log.e("StudyFormViewModel-createNotificationKey", it.message ?: "error occurred.")
+            }
+        }
+    }
+
+    private fun addNotificationKey(sid: String, notificationKey: String) {
+        viewModelScope.launch {
+            kotlin.runCatching {
+                studyRepository.addNotificationKey(sid, notificationKey)
+            }.onSuccess {
+                addRegistrationId(sid, fcmTokenRepository.getToken().first())
+            }.onFailure {
+                Log.e("StudyFormViewModel-addNotificationKey", it.message ?: "error occurred.")
+            }
+        }
+    }
+
+    private fun addRegistrationId(sid: String, registrationId: String) {
+        viewModelScope.launch {
+            kotlin.runCatching {
+                studyRepository.addRegistrationId(sid, registrationId)
+            }.onSuccess {
+                _createNotificationKeyEvent.value = Event(Unit)
+            }.onFailure {
+                Log.e("StudyFormViewModel-addRegistrationId", it.message ?: "error occurred.")
+            }
+        }
+    }
+
+    fun moveToMessage(sid: String) {
+        _moveToMessageEvent.value = Event(sid)
+    }
+
+    companion object {
+        fun create(fcmTokenRepository: FcmTokenRepository) = viewModelFactory {
+            initializer {
+                StudyFormViewModel(fcmTokenRepository)
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,6 +33,7 @@
     <string name="all_sunday">일</string>
     <string name="all_search_hint">스터디 검색</string>
     <string name="all_icon_person_description">사람 모양의 아이콘</string>
+    <string name="all_notification_info">이 앱은 알림을 표시하지 않습니다. 설정에서 알림 권한을 변경할 수 있습니다.</string>
 
     <string name="login_auto_login_key">AUTO_LOGIN</string>
     <string name="login_github">Login with Github</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,6 +3,8 @@
 
     <string name="application_pref_file_key">com.sesac.developer_study_platform.DEVELOPER_STUDY_APP</string>
 
+    <string name="default_notification_channel_id">fcm_default_channel</string>
+
     <string name="main_home">홈</string>
     <string name="main_search">검색</string>
     <string name="main_study_form">방만들기</string>


### PR DESCRIPTION
## 작업 내용
- [x] fcm 사용자 디바이스 토큰 datastore에 저장 및 불러오기
- [x] 새로운 토큰이 생성될 때마다 datastore에 저장
- [x] fcm 서버 및 데이터베이스에 notification key, 사용자 디바이스 토큰 저장

## 체크리스트
- [x] Assignees 설정
- [x] Labels 설정
- [x] Projects 설정
- [x] Milestone 설정

## 기타
- 다른 브랜치에서 수정된 부분이 있어서 스터디 참여 다이얼로그, MessageViewModel 부분 빼고 코드 리뷰해주셔도 될 것 같습니다!
- 혹시 이해가 안가신다면 [알림 권한 요청 로직](https://github.com/android-team-02/developer-study-platform/wiki/FCM-%EA%B7%B8%EB%A3%B9-%EC%B1%84%ED%8C%85-%EC%95%8C%EB%A6%BC) 참고해주세요🫨