### PR TITLE
알림 권한 근거 다이얼로그 구현

### DIFF
--- a/app/src/main/java/com/sesac/developer_study_platform/data/source/remote/StudyRepository.kt
+++ b/app/src/main/java/com/sesac/developer_study_platform/data/source/remote/StudyRepository.kt
@@ -102,6 +102,10 @@ class StudyRepository {
         studyService.addRegistrationId(sid, mapOf(registrationId to true))
     }
 
+    suspend fun getRegistrationIdList(sid: String): Map<String, Boolean> {
+        return studyService.getRegistrationIdList(sid)
+    }
+
     fun getMessageList(sid: String): Flow<Map<String, Message>> = flow {
         while (true) {
             kotlin.runCatching {

--- a/app/src/main/java/com/sesac/developer_study_platform/data/source/remote/StudyService.kt
+++ b/app/src/main/java/com/sesac/developer_study_platform/data/source/remote/StudyService.kt
@@ -167,6 +167,11 @@ interface StudyService {
         @Body registrationId: Map<String, Boolean>
     )
 
+    @GET("studies/{sid}/registrationIds.json")
+    suspend fun getRegistrationIdList(
+        @Path("sid") sid: String
+    ): Map<String, Boolean>
+
     companion object {
         private const val BASE_URL = BuildConfig.FIREBASE_BASE_URL
         private val contentType = "application/json".toMediaType()

--- a/app/src/main/java/com/sesac/developer_study_platform/ui/common/NotificationPermissionDialogFragment.kt
+++ b/app/src/main/java/com/sesac/developer_study_platform/ui/common/NotificationPermissionDialogFragment.kt
@@ -1,0 +1,91 @@
+package com.sesac.developer_study_platform.ui.common
+
+import android.Manifest
+import android.os.Build
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
+import com.sesac.developer_study_platform.EventObserver
+import com.sesac.developer_study_platform.R
+import com.sesac.developer_study_platform.data.source.local.FcmTokenRepository
+import com.sesac.developer_study_platform.databinding.DialogNotificationPermissionBinding
+
+class NotificationPermissionDialogFragment : DialogFragment() {
+
+    private var _binding: DialogNotificationPermissionBinding? = null
+    private val binding get() = _binding!!
+    private val viewModel by viewModels<NotificationPermissionDialogViewModel> {
+        NotificationPermissionDialogViewModel.create(FcmTokenRepository(requireContext()))
+    }
+    private val args by navArgs<NotificationPermissionDialogFragmentArgs>()
+    private val requestPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
+            if (isGranted) {
+                checkNotificationKey()
+            } else {
+                Toast.makeText(context, getString(R.string.all_notification_info), Toast.LENGTH_SHORT).show()
+                viewModel.moveToMessage(args.studyId)
+            }
+        }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = DialogNotificationPermissionBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        setYesButton()
+        binding.btnNo.setOnClickListener {
+            viewModel.moveToMessage(args.studyId)
+        }
+        setNavigation()
+    }
+
+    private fun setYesButton() {
+        binding.btnYes.setOnClickListener {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+            } else {
+                checkNotificationKey()
+            }
+        }
+    }
+
+    private fun checkNotificationKey() {
+        viewModel.checkNotificationKey(args.studyId)
+        viewModel.checkNotificationKeyEvent.observe(
+            viewLifecycleOwner,
+            EventObserver {
+                viewModel.moveToMessage(args.studyId)
+            }
+        )
+    }
+
+    private fun setNavigation() {
+        viewModel.moveToMessageEvent.observe(
+            viewLifecycleOwner,
+            EventObserver {
+                val action = NotificationPermissionDialogFragmentDirections.actionGlobalToMessage(it)
+                findNavController().navigate(action)
+            }
+        )
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/sesac/developer_study_platform/ui/common/NotificationPermissionDialogViewModel.kt
+++ b/app/src/main/java/com/sesac/developer_study_platform/ui/common/NotificationPermissionDialogViewModel.kt
@@ -1,0 +1,142 @@
+package com.sesac.developer_study_platform.ui.common
+
+import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.sesac.developer_study_platform.Event
+import com.sesac.developer_study_platform.StudyApplication.Companion.fcmRepository
+import com.sesac.developer_study_platform.StudyApplication.Companion.studyRepository
+import com.sesac.developer_study_platform.data.StudyGroup
+import com.sesac.developer_study_platform.data.source.local.FcmTokenRepository
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+
+class NotificationPermissionDialogViewModel(private val fcmTokenRepository: FcmTokenRepository) :
+    ViewModel() {
+
+    private val _checkNotificationKeyEvent: MutableLiveData<Event<Unit>> = MutableLiveData()
+    val checkNotificationKeyEvent: LiveData<Event<Unit>> = _checkNotificationKeyEvent
+
+    private val _moveToMessageEvent: MutableLiveData<Event<String>> = MutableLiveData()
+    val moveToMessageEvent: LiveData<Event<String>> = _moveToMessageEvent
+
+    fun checkNotificationKey(sid: String) {
+        viewModelScope.launch {
+            if (getNotificationKey(sid).isNullOrEmpty()) {
+                createNotificationKey(sid)
+            } else if (isRegistrationId(sid, fcmTokenRepository.getToken().first())) {
+                updateStudyGroup(sid)
+            }
+        }
+    }
+
+    private fun createNotificationKey(sid: String) {
+        viewModelScope.launch {
+            val token = fcmTokenRepository.getToken().first()
+            kotlin.runCatching {
+                fcmRepository.updateStudyGroup(StudyGroup("create", sid, listOf(token)))
+            }.onSuccess {
+                addNotificationKey(sid, it.values.first())
+            }.onFailure {
+                Log.e(
+                    "NotificationPermissionDialogViewModel-createNotificationKey",
+                    it.message ?: "error occurred."
+                )
+            }
+        }
+    }
+
+    private fun addNotificationKey(sid: String, notificationKey: String) {
+        viewModelScope.launch {
+            kotlin.runCatching {
+                studyRepository.addNotificationKey(sid, notificationKey)
+            }.onSuccess {
+                addRegistrationId(sid, fcmTokenRepository.getToken().first())
+            }.onFailure {
+                Log.e(
+                    "NotificationPermissionDialogViewModel-addNotificationKey",
+                    it.message ?: "error occurred."
+                )
+            }
+        }
+    }
+
+    private fun updateStudyGroup(sid: String) {
+        viewModelScope.launch {
+            val token = fcmTokenRepository.getToken().first()
+            kotlin.runCatching {
+                val notificationKey = getNotificationKey(sid)
+                if (!notificationKey.isNullOrEmpty()) {
+                    fcmRepository.updateStudyGroup(StudyGroup("add", sid, listOf(token), notificationKey))
+                }
+            }.onSuccess {
+                addRegistrationId(sid, token)
+            }.onFailure {
+                Log.e(
+                    "NotificationPermissionDialogViewModel-updateStudyGroup",
+                    it.message ?: "error occurred."
+                )
+            }
+        }
+    }
+
+    private suspend fun getNotificationKey(sid: String): String? {
+        return viewModelScope.async {
+            kotlin.runCatching {
+                studyRepository.getNotificationKey(sid)
+            }.onFailure {
+                Log.e(
+                    "NotificationPermissionDialogViewModel-getNotificationKey",
+                    it.message ?: "error occurred."
+                )
+            }.getOrNull()
+        }.await()
+    }
+
+    private fun addRegistrationId(sid: String, registrationId: String) {
+        viewModelScope.launch {
+            kotlin.runCatching {
+                studyRepository.addRegistrationId(sid, registrationId)
+            }.onSuccess {
+                _checkNotificationKeyEvent.value = Event(Unit)
+            }.onFailure {
+                Log.e(
+                    "NotificationPermissionDialogViewModel-addRegistrationId",
+                    it.message ?: "error occurred."
+                )
+            }
+        }
+    }
+
+    private suspend fun isRegistrationId(sid: String, registrationId: String): Boolean {
+        return viewModelScope.async {
+            kotlin.runCatching {
+                studyRepository.getRegistrationIdList(sid)
+            }.map {
+                it.containsKey(registrationId)
+            }.onFailure {
+                Log.e(
+                    "NotificationPermissionDialogViewModel-isRegistrationId",
+                    it.message ?: "error occurred."
+                )
+            }.getOrDefault(false)
+        }.await()
+    }
+
+    fun moveToMessage(sid: String) {
+        _moveToMessageEvent.value = Event(sid)
+    }
+
+    companion object {
+        fun create(fcmTokenRepository: FcmTokenRepository) = viewModelFactory {
+            initializer {
+                NotificationPermissionDialogViewModel(fcmTokenRepository)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/sesac/developer_study_platform/ui/detail/JoinStudyDialogFragment.kt
+++ b/app/src/main/java/com/sesac/developer_study_platform/ui/detail/JoinStudyDialogFragment.kt
@@ -87,10 +87,25 @@ class JoinStudyDialogFragment : DialogFragment() {
     }
 
     private fun setNavigation() {
+        moveToMessage()
+        moveToNotificationPermissionDialog()
+    }
+
+    private fun moveToMessage() {
         viewModel.moveToMessageEvent.observe(
             viewLifecycleOwner,
             EventObserver {
                 val action = JoinStudyDialogFragmentDirections.actionJoinStudyDialogToMessage(it)
+                findNavController().navigate(action)
+            }
+        )
+    }
+
+    private fun moveToNotificationPermissionDialog() {
+        viewModel.moveToNotificationPermissionDialogEvent.observe(
+            viewLifecycleOwner,
+            EventObserver {
+                val action = JoinStudyDialogFragmentDirections.actionGlobalToNotificationPermissionDialog(it)
                 findNavController().navigate(action)
             }
         )
@@ -107,7 +122,7 @@ class JoinStudyDialogFragment : DialogFragment() {
                 }
 
                 shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS) -> {
-                    // TODO 권한 이유 다이얼로그
+                    viewModel.moveToNotificationPermissionDialog(args.study.sid)
                 }
 
                 else -> {

--- a/app/src/main/java/com/sesac/developer_study_platform/ui/detail/JoinStudyDialogFragment.kt
+++ b/app/src/main/java/com/sesac/developer_study_platform/ui/detail/JoinStudyDialogFragment.kt
@@ -7,7 +7,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.WindowManager
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
@@ -51,22 +50,11 @@ class JoinStudyDialogFragment : DialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        setDialog()
         setNavigation()
         setYesButton()
         binding.btnNo.setOnClickListener {
             dismiss()
         }
-    }
-
-    private fun setDialog() {
-        val displayMetrics = resources.displayMetrics
-        val widthPixels = displayMetrics.widthPixels
-
-        val params = dialog?.window?.attributes
-        params?.width = (widthPixels * 0.9).toInt()
-        dialog?.window?.attributes = params as WindowManager.LayoutParams
-        dialog?.window?.setBackgroundDrawableResource(R.drawable.bg_white_radius_18dp)
     }
 
     private fun setYesButton() {

--- a/app/src/main/java/com/sesac/developer_study_platform/ui/detail/JoinStudyDialogViewModel.kt
+++ b/app/src/main/java/com/sesac/developer_study_platform/ui/detail/JoinStudyDialogViewModel.kt
@@ -30,6 +30,10 @@ class JoinStudyDialogViewModel(private val fcmTokenRepository: FcmTokenRepositor
     private val _moveToMessageEvent: MutableLiveData<Event<String>> = MutableLiveData()
     val moveToMessageEvent: LiveData<Event<String>> = _moveToMessageEvent
 
+    private val _moveToNotificationPermissionDialogEvent: MutableLiveData<Event<String>> = MutableLiveData()
+    val moveToNotificationPermissionDialogEvent: LiveData<Event<String>> =
+        _moveToNotificationPermissionDialogEvent
+
     fun addUserStudy(sid: String, study: UserStudy) {
         viewModelScope.launch {
             kotlin.runCatching {
@@ -100,6 +104,10 @@ class JoinStudyDialogViewModel(private val fcmTokenRepository: FcmTokenRepositor
 
     fun moveToMessage(sid: String) {
         _moveToMessageEvent.value = Event(sid)
+    }
+
+    fun moveToNotificationPermissionDialog(sid: String) {
+        _moveToNotificationPermissionDialogEvent.value = Event(sid)
     }
 
     companion object {

--- a/app/src/main/java/com/sesac/developer_study_platform/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/sesac/developer_study_platform/ui/main/MainActivity.kt
@@ -60,6 +60,7 @@ class MainActivity : AppCompatActivity() {
                 R.id.dest_exit_dialog -> View.GONE
                 R.id.dest_ban_dialog -> View.GONE
                 R.id.dest_join_study_dialog -> View.GONE
+                R.id.dest_notification_permission_dialog -> View.GONE
                 else -> View.VISIBLE
             }
         }

--- a/app/src/main/java/com/sesac/developer_study_platform/ui/message/ExitDialogFragment.kt
+++ b/app/src/main/java/com/sesac/developer_study_platform/ui/message/ExitDialogFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.WindowManager
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -32,7 +31,6 @@ class ExitDialogFragment : DialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        setDialog()
         setNavigation()
         binding.btnNo.setOnClickListener {
             dismiss()
@@ -40,16 +38,6 @@ class ExitDialogFragment : DialogFragment() {
         binding.btnYes.setOnClickListener {
             viewModel.deleteStudyMember(args.studyId)
         }
-    }
-
-    private fun setDialog() {
-        val displayMetrics = resources.displayMetrics
-        val widthPixels = displayMetrics.widthPixels
-
-        val params = dialog?.window?.attributes
-        params?.width = (widthPixels * 0.9).toInt()
-        dialog?.window?.attributes = params as WindowManager.LayoutParams
-        dialog?.window?.setBackgroundDrawableResource(R.drawable.bg_white_radius_18dp)
     }
 
     private fun setNavigation() {

--- a/app/src/main/java/com/sesac/developer_study_platform/ui/mypage/LogoutDialogFragment.kt
+++ b/app/src/main/java/com/sesac/developer_study_platform/ui/mypage/LogoutDialogFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.WindowManager
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -29,8 +28,6 @@ class LogoutDialogFragment : DialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        setDialogSize()
-        dialog?.window?.setBackgroundDrawableResource(R.drawable.bg_white_radius_18dp)
         setNavigation()
         binding.btnNo.setOnClickListener {
             dismiss()
@@ -38,15 +35,6 @@ class LogoutDialogFragment : DialogFragment() {
         binding.btnYes.setOnClickListener {
             viewModel.startLogout()
         }
-    }
-
-    private fun setDialogSize() {
-        val displayMetrics = resources.displayMetrics
-        val widthPixels = displayMetrics.widthPixels
-
-        val params = dialog?.window?.attributes
-        params?.width = (widthPixels * 0.9).toInt()
-        dialog?.window?.attributes = params as WindowManager.LayoutParams
     }
 
     private fun setNavigation() {

--- a/app/src/main/java/com/sesac/developer_study_platform/ui/profile/BanDialogFragment.kt
+++ b/app/src/main/java/com/sesac/developer_study_platform/ui/profile/BanDialogFragment.kt
@@ -4,13 +4,11 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.WindowManager
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.sesac.developer_study_platform.EventObserver
-import com.sesac.developer_study_platform.R
 import com.sesac.developer_study_platform.databinding.DialogBanBinding
 
 class BanDialogFragment : DialogFragment() {
@@ -32,7 +30,6 @@ class BanDialogFragment : DialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        setDialog()
         setNavigation()
         binding.btnNo.setOnClickListener {
             dismiss()
@@ -40,16 +37,6 @@ class BanDialogFragment : DialogFragment() {
         binding.btnYes.setOnClickListener {
             viewModel.deleteStudyMember(args.studyId, args.uid)
         }
-    }
-
-    private fun setDialog() {
-        val displayMetrics = resources.displayMetrics
-        val widthPixels = displayMetrics.widthPixels
-
-        val params = dialog?.window?.attributes
-        params?.width = (widthPixels * 0.9).toInt()
-        dialog?.window?.attributes = params as WindowManager.LayoutParams
-        dialog?.window?.setBackgroundDrawableResource(R.drawable.bg_white_radius_18dp)
     }
 
     private fun setNavigation() {

--- a/app/src/main/java/com/sesac/developer_study_platform/ui/studyform/StudyFormFragment.kt
+++ b/app/src/main/java/com/sesac/developer_study_platform/ui/studyform/StudyFormFragment.kt
@@ -456,10 +456,25 @@ class StudyFormFragment : Fragment() {
     }
 
     private fun setNavigation() {
+        moveToMessage()
+        moveToNotificationPermissionDialog()
+    }
+
+    private fun moveToMessage() {
         viewModel.moveToMessageEvent.observe(
             viewLifecycleOwner,
             EventObserver {
                 val action = StudyFormFragmentDirections.actionStudyFormToMessage(it)
+                findNavController().navigate(action)
+            }
+        )
+    }
+
+    private fun moveToNotificationPermissionDialog() {
+        viewModel.moveToNotificationPermissionDialogEvent.observe(
+            viewLifecycleOwner,
+            EventObserver {
+                val action = StudyFormFragmentDirections.actionGlobalToNotificationPermissionDialog(it)
                 findNavController().navigate(action)
             }
         )
@@ -476,7 +491,7 @@ class StudyFormFragment : Fragment() {
                 }
 
                 shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS) -> {
-                    // TODO 권한 이유 다이얼로그
+                    viewModel.moveToNotificationPermissionDialog(sid)
                 }
 
                 else -> {

--- a/app/src/main/java/com/sesac/developer_study_platform/ui/studyform/StudyFormViewModel.kt
+++ b/app/src/main/java/com/sesac/developer_study_platform/ui/studyform/StudyFormViewModel.kt
@@ -23,6 +23,10 @@ class StudyFormViewModel(private val fcmTokenRepository: FcmTokenRepository) : V
     private val _moveToMessageEvent: MutableLiveData<Event<String>> = MutableLiveData()
     val moveToMessageEvent: LiveData<Event<String>> = _moveToMessageEvent
 
+    private val _moveToNotificationPermissionDialogEvent: MutableLiveData<Event<String>> = MutableLiveData()
+    val moveToNotificationPermissionDialogEvent: LiveData<Event<String>> =
+        _moveToNotificationPermissionDialogEvent
+
     fun createNotificationKey(sid: String) {
         viewModelScope.launch {
             val token = fcmTokenRepository.getToken().first()
@@ -62,6 +66,10 @@ class StudyFormViewModel(private val fcmTokenRepository: FcmTokenRepository) : V
 
     fun moveToMessage(sid: String) {
         _moveToMessageEvent.value = Event(sid)
+    }
+
+    fun moveToNotificationPermissionDialog(sid: String) {
+        _moveToNotificationPermissionDialogEvent.value = Event(sid)
     }
 
     companion object {

--- a/app/src/main/res/drawable/bg_white_radius_18dp.xml
+++ b/app/src/main/res/drawable/bg_white_radius_18dp.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <solid android:color="@color/white" />
-    <corners android:radius="18dp" />
-</shape>
+<inset xmlns:android="http://schemas.android.com/apk/res/android"
+    android:inset="16dp">
+    <shape android:shape="rectangle">
+        <corners android:radius="18dp" />
+        <solid android:color="@color/white" />
+    </shape>
+</inset>

--- a/app/src/main/res/layout/dialog_notification_permission.xml
+++ b/app/src/main/res/layout/dialog_notification_permission.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <ImageView
+        android:id="@+id/iv_logo"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/space_median"
+        android:contentDescription="@null"
+        android:src="@drawable/ic_launcher_foreground"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/tv_notification_permission"
+        style="@style/BlackText.Medium"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:fontFamily="@font/pretendard_bold"
+        android:gravity="center"
+        android:text="@string/dialog_notification_permission"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/iv_logo" />
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/btn_no"
+        style="@style/BlackText.Medium"
+        android:layout_width="0dp"
+        android:layout_height="52dp"
+        android:layout_marginVertical="@dimen/space_median"
+        android:layout_marginStart="@dimen/space_x_large"
+        android:layout_marginEnd="@dimen/space_x_small"
+        android:background="@drawable/bg_lilac_radius_12dp"
+        android:fontFamily="@font/pretendard_bold"
+        android:text="@string/all_no"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/btn_yes"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_notification_permission" />
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/btn_yes"
+        style="@style/WhiteText.Medium"
+        android:layout_width="0dp"
+        android:layout_height="52dp"
+        android:layout_marginStart="@dimen/space_x_small"
+        android:layout_marginEnd="@dimen/space_x_large"
+        android:background="@drawable/bg_black_radius_12dp"
+        android:fontFamily="@font/pretendard_bold"
+        android:text="@string/all_yes"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/btn_no"
+        app:layout_constraintTop_toBottomOf="@id/tv_notification_permission" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -17,6 +17,10 @@
         android:id="@+id/action_global_to_message"
         app:destination="@id/dest_message" />
 
+    <action
+        android:id="@+id/action_global_to_notification_permission_dialog"
+        app:destination="@id/dest_notification_permission_dialog" />
+
     <fragment
         android:id="@+id/dest_login"
         android:name="com.sesac.developer_study_platform.ui.login.LoginFragment"
@@ -236,4 +240,14 @@
             android:name="url"
             app:argType="string" />
     </fragment>
+
+    <dialog
+        android:id="@+id/dest_notification_permission_dialog"
+        android:name="com.sesac.developer_study_platform.ui.common.NotificationPermissionDialogFragment"
+        android:label="fragment_notification_permission_dialog"
+        tools:layout="@layout/dialog_notification_permission">
+        <argument
+            android:name="studyId"
+            app:argType="string" />
+    </dialog>
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,6 +66,7 @@
     <string name="dialog_logout">로그아웃 하시겠습니까?</string>
     <string name="dialog_ban">내보내기 하시겠습니까?</string>
     <string name="dialog_chat_exit">채팅방을 나가시겠습니까?</string>
+    <string name="dialog_notification_permission">채팅 알림 기능을 제공하기 위해 알림 권한이 필요합니다.\n계속 진행하시겠습니까?</string>
 
     <string name="profile_ban">내보내기</string>
     <string name="profile_repository">Repository</string>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -2,6 +2,7 @@
 
     <style name="Base.Theme.Developerstudyplatform" parent="Theme.Material3.DayNight.NoActionBar">
         <item name="colorPrimary">@color/black</item>
+        <item name="android:dialogTheme">@style/Theme.App.Dialog</item>
     </style>
 
     <style name="Theme.Developerstudyplatform" parent="Base.Theme.Developerstudyplatform" />
@@ -10,5 +11,9 @@
         <item name="windowSplashScreenBackground">@color/white</item>
         <item name="windowSplashScreenAnimatedIcon">@drawable/ic_launcher_foreground</item>
         <item name="postSplashScreenTheme">@style/Theme.Developerstudyplatform</item>
+    </style>
+
+    <style name="Theme.App.Dialog" parent="Theme.MaterialComponents.Dialog.Alert">
+        <item name="android:windowBackground">@drawable/bg_white_radius_18dp</item>
     </style>
 </resources>


### PR DESCRIPTION
## 작업 내용
- [x] 알림 권한 다이얼로그 레이아웃 구현
- [x] 스터디 만들기 화면, 스터디 참여 다이얼로그에서 알림 권한 다이얼로그로 이동
- [x] 다이얼로그 스타일 themes에 적용

## 체크리스트
- [x] Assignees 설정
- [x] Labels 설정
- [x] Projects 설정
- [x] Milestone 설정

## 기타
- 다른 브랜치에서 수정된 부분이 있어서 ViewModel 부분 빼고 코드 리뷰해주셔도 될 것 같습니다!
- 혹시 이해가 안가신다면 [알림 권한 요청 로직](https://github.com/android-team-02/developer-study-platform/wiki/FCM-%EA%B7%B8%EB%A3%B9-%EC%B1%84%ED%8C%85-%EC%95%8C%EB%A6%BC) 참고해주세요🫨
