### PR TITLE
화면별 알림 권한 요청 및 채팅방 별로 알림 설정 구현

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -39,6 +39,9 @@
             android:name="com.google.firebase.messaging.default_notification_icon"
             android:resource="@drawable/ic_launcher_foreground" />
         <meta-data
+            android:name="com.google.firebase.messaging.default_notification_color"
+            android:resource="@color/white" />
+        <meta-data
             android:name="com.google.firebase.messaging.default_notification_channel_id"
             android:value="@string/default_notification_channel_id" />
     </application>

--- a/app/src/main/java/com/sesac/developer_study_platform/MyFirebaseMessagingService.kt
+++ b/app/src/main/java/com/sesac/developer_study_platform/MyFirebaseMessagingService.kt
@@ -1,12 +1,24 @@
 package com.sesac.developer_study_platform
 
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Intent
+import android.graphics.Bitmap
+import android.os.Build
 import android.util.Log
+import androidx.core.app.NotificationCompat
+import com.bumptech.glide.Glide
+import com.google.firebase.Firebase
+import com.google.firebase.auth.auth
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import com.sesac.developer_study_platform.data.source.local.FcmTokenRepository
+import com.sesac.developer_study_platform.ui.main.MainActivity
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlin.random.Random
 
 class MyFirebaseMessagingService : FirebaseMessagingService() {
 
@@ -21,18 +33,76 @@ class MyFirebaseMessagingService : FirebaseMessagingService() {
     }
 
     override fun onMessageReceived(remoteMessage: RemoteMessage) {
-        // TODO(developer): Handle FCM messages here.
-        // Not getting messages here? See why this may be: https://goo.gl/39bRNJ
-        Log.d("fcm", "From: ${remoteMessage.from}")
+        kotlin.runCatching {
+            if (remoteMessage.data.isNotEmpty()) {
+                val uid = remoteMessage.data.getValue("uid")
 
-        // Check if message contains a data payload.
-        if (remoteMessage.data.isNotEmpty()) {
-            Log.d("fcm", "Message data payload: ${remoteMessage.data}")
+                createNotificationChannel()
+                if (uid != Firebase.auth.uid) {
+                    sendNotification(remoteMessage.data)
+                }
+            }
+        }.onFailure {
+            Log.e("MyFirebaseMessagingService-onMessageReceived", it.message ?: "error occurred.")
         }
+    }
 
-        // Check if message contains a notification payload.
-        remoteMessage.notification?.let {
-            Log.d("fcm", "Message Notification Body: ${it.body}")
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val id = getString(R.string.default_notification_channel_id)
+            val name = getString(R.string.app_name)
+            val descriptionText = getString(R.string.app_name)
+            val importance = NotificationManager.IMPORTANCE_DEFAULT
+            val channel = NotificationChannel(id, name, importance).apply {
+                description = descriptionText
+            }
+            val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+
+            notificationManager.createNotificationChannel(channel)
         }
+    }
+
+
+    private fun sendNotification(data: Map<String, String>) {
+        kotlin.runCatching {
+            val randomNumber = Random.nextInt()
+            val builder = getNotificationBuilder(data, randomNumber)
+            val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+
+            notificationManager.notify(randomNumber, builder.build())
+        }.onFailure {
+            Log.e("MyFirebaseMessagingService-sendNotification", it.message ?: "error occurred.")
+        }
+    }
+
+    private fun getNotificationBuilder(
+        data: Map<String, String>,
+        randomNumber: Int
+    ): NotificationCompat.Builder {
+        return NotificationCompat.Builder(this, getString(R.string.default_notification_channel_id))
+            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setLargeIcon(getLargeIcon(data.getValue("imageUrl")))
+            .setColor(getColor(R.color.white))
+            .setContentTitle(data.getValue("title"))
+            .setContentText(data.getValue("text"))
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setContentIntent(getPendingIntent(data, randomNumber))
+            .setAutoCancel(true)
+    }
+
+    private fun getLargeIcon(imageUrl: String): Bitmap {
+        return Glide.with(this)
+            .asBitmap()
+            .load(imageUrl)
+            .submit()
+            .get()
+    }
+
+    private fun getPendingIntent(data: Map<String, String>, randomNumber: Int): PendingIntent? {
+        val intent = Intent(this, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            putExtra("sid", data.getValue("sid"))
+        }
+        return PendingIntent.getActivity(this, randomNumber, intent, PendingIntent.FLAG_IMMUTABLE)
     }
 }

--- a/app/src/main/java/com/sesac/developer_study_platform/data/FcmMessage.kt
+++ b/app/src/main/java/com/sesac/developer_study_platform/data/FcmMessage.kt
@@ -10,5 +10,14 @@ data class FcmMessage(
 @Serializable
 data class FcmMessageData(
     val token: String = "",
-    val data: Map<String, String> = mapOf(),
+    val data: FcmMessageContent,
+)
+
+@Serializable
+data class FcmMessageContent(
+    val uid: String? = "",
+    val sid: String? = "",
+    val title: String = "",
+    val text: String = "",
+    val imageUrl: String = "",
 )

--- a/app/src/main/java/com/sesac/developer_study_platform/data/FcmMessage.kt
+++ b/app/src/main/java/com/sesac/developer_study_platform/data/FcmMessage.kt
@@ -11,6 +11,7 @@ data class FcmMessage(
 data class FcmMessageData(
     val token: String = "",
     val data: FcmMessageContent,
+    val android: Map<String, Boolean> = mapOf()
 )
 
 @Serializable

--- a/app/src/main/java/com/sesac/developer_study_platform/data/source/remote/StudyRepository.kt
+++ b/app/src/main/java/com/sesac/developer_study_platform/data/source/remote/StudyRepository.kt
@@ -106,6 +106,14 @@ class StudyRepository {
         return studyService.getRegistrationIdList(sid)
     }
 
+    suspend fun deleteRegistrationId(sid: String, registrationId: String) {
+        studyService.deleteRegistrationId(sid, registrationId)
+    }
+
+    suspend fun deleteNotificationKey(sid: String) {
+        studyService.deleteNotificationKey(sid)
+    }
+
     fun getMessageList(sid: String): Flow<Map<String, Message>> = flow {
         while (true) {
             kotlin.runCatching {

--- a/app/src/main/java/com/sesac/developer_study_platform/data/source/remote/StudyService.kt
+++ b/app/src/main/java/com/sesac/developer_study_platform/data/source/remote/StudyService.kt
@@ -172,6 +172,17 @@ interface StudyService {
         @Path("sid") sid: String
     ): Map<String, Boolean>
 
+    @DELETE("studies/{sid}/registrationIds/{registrationId}.json")
+    suspend fun deleteRegistrationId(
+        @Path("sid") sid: String,
+        @Path("registrationId") registrationId: String
+    )
+
+    @DELETE("studies/{sid}/notificationKey.json")
+    suspend fun deleteNotificationKey(
+        @Path("sid") sid: String
+    )
+
     companion object {
         private const val BASE_URL = BuildConfig.FIREBASE_BASE_URL
         private val contentType = "application/json".toMediaType()

--- a/app/src/main/java/com/sesac/developer_study_platform/ui/detail/JoinStudyDialogFragment.kt
+++ b/app/src/main/java/com/sesac/developer_study_platform/ui/detail/JoinStudyDialogFragment.kt
@@ -31,7 +31,7 @@ class JoinStudyDialogFragment : DialogFragment() {
     private val requestPermissionLauncher =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
             if (isGranted) {
-                updateStudyGroup()
+                checkNotificationKey()
             } else {
                 Toast.makeText(context, getString(R.string.all_notification_info), Toast.LENGTH_SHORT).show()
                 viewModel.moveToMessage(args.study.sid)
@@ -106,7 +106,7 @@ class JoinStudyDialogFragment : DialogFragment() {
                     requireContext(),
                     Manifest.permission.POST_NOTIFICATIONS
                 ) == PackageManager.PERMISSION_GRANTED -> {
-                    updateStudyGroup()
+                    checkNotificationKey()
                 }
 
                 shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS) -> {
@@ -118,13 +118,13 @@ class JoinStudyDialogFragment : DialogFragment() {
                 }
             }
         } else {
-            updateStudyGroup()
+            checkNotificationKey()
         }
     }
 
-    private fun updateStudyGroup() {
-        viewModel.updateStudyGroup(args.study.sid)
-        viewModel.updateStudyGroupEvent.observe(
+    private fun checkNotificationKey() {
+        viewModel.checkNotificationKey(args.study.sid)
+        viewModel.checkNotificationKeyEvent.observe(
             viewLifecycleOwner,
             EventObserver {
                 viewModel.moveToMessage(args.study.sid)

--- a/app/src/main/java/com/sesac/developer_study_platform/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/sesac/developer_study_platform/ui/main/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.sesac.developer_study_platform.ui.main
 
 import android.animation.ObjectAnimator
+import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import android.view.animation.AnticipateInterpolator
@@ -18,20 +19,29 @@ class MainActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityMainBinding
     private lateinit var splashScreen: SplashScreen
+    private lateinit var navController: NavController
 
     override fun onCreate(savedInstanceState: Bundle?) {
         splashScreen = installSplashScreen()
         super.onCreate(savedInstanceState)
-        startSplash()
+//        startSplash()
 
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
         val navHostFragment = supportFragmentManager.findFragmentById(R.id.fcv) as NavHostFragment
-        val navController = navHostFragment.navController
+        navController = navHostFragment.navController
         binding.bnv.setupWithNavController(navController)
 
         hideBottomNavigationView(navController)
+
+        setNewIntent(intent)
+    }
+
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+
+        setNewIntent(intent)
     }
 
     private fun startSplash() {
@@ -62,6 +72,16 @@ class MainActivity : AppCompatActivity() {
                 R.id.dest_join_study_dialog -> View.GONE
                 R.id.dest_notification_permission_dialog -> View.GONE
                 else -> View.VISIBLE
+            }
+        }
+    }
+
+    private fun setNewIntent(intent: Intent?) {
+        if (intent != null) {
+            val sid = intent.getStringExtra("sid")
+            if (!sid.isNullOrEmpty()) {
+                val action = MainActivityDirections.actionGlobalToMessage(sid)
+                navController.navigate(action)
             }
         }
     }

--- a/app/src/main/java/com/sesac/developer_study_platform/ui/message/MessageFragment.kt
+++ b/app/src/main/java/com/sesac/developer_study_platform/ui/message/MessageFragment.kt
@@ -1,13 +1,18 @@
 package com.sesac.developer_study_platform.ui.message
 
+import android.Manifest
+import android.content.pm.PackageManager
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
 import androidx.core.view.GravityCompat
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
@@ -20,6 +25,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.sesac.developer_study_platform.EventObserver
 import com.sesac.developer_study_platform.R
 import com.sesac.developer_study_platform.data.StudyMember
+import com.sesac.developer_study_platform.data.source.local.FcmTokenRepository
 import com.sesac.developer_study_platform.data.source.remote.StudyService
 import com.sesac.developer_study_platform.databinding.FragmentMessageBinding
 import com.sesac.developer_study_platform.util.isNetworkConnected
@@ -32,7 +38,9 @@ class MessageFragment : Fragment() {
     private val binding get() = _binding!!
     private val args by navArgs<MessageFragmentArgs>()
     private val messageAdapter = MessageAdapter()
-    private val viewModel by viewModels<MessageViewModel>()
+    private val viewModel by viewModels<MessageViewModel> {
+        MessageViewModel.create(FcmTokenRepository(requireContext()))
+    }
     private val service = StudyService.create()
     private var isBottom = true
     private val pickMultipleMedia =
@@ -45,6 +53,14 @@ class MessageFragment : Fragment() {
             findNavController().navigate(action)
         }
     })
+    private val requestPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
+            if (isGranted) {
+                addRegistrationId()
+            } else {
+                Toast.makeText(context, getString(R.string.all_notification_info), Toast.LENGTH_SHORT).show()
+            }
+        }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -70,6 +86,8 @@ class MessageFragment : Fragment() {
         setSendButton()
         setExitButton()
         setExitButtonVisibility()
+        loadNotificationButtonState()
+        setNotificationButton()
         setNavigation()
         binding.isNetworkConnected = isNetworkConnected(requireContext())
     }
@@ -210,9 +228,69 @@ class MessageFragment : Fragment() {
         )
     }
 
+    private fun loadNotificationButtonState() {
+        lifecycleScope.launch {
+            binding.ivNotification.isSelected = viewModel.isRegistrationId(args.studyId)
+        }
+    }
+
+    private fun setNotificationButton() {
+        binding.ivNotification.setOnClickListener {
+            if (binding.ivNotification.isSelected) {
+                deleteRegistrationId()
+            } else {
+                askNotificationPermission()
+            }
+        }
+    }
+
+    private fun deleteRegistrationId() {
+        viewModel.updateStudyGroup("remove", args.studyId)
+        viewModel.deleteRegistrationIdEvent.observe(
+            viewLifecycleOwner,
+            EventObserver {
+                binding.ivNotification.isSelected = false
+            }
+        )
+    }
+
+    private fun askNotificationPermission() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            when {
+                ContextCompat.checkSelfPermission(
+                    requireContext(),
+                    Manifest.permission.POST_NOTIFICATIONS
+                ) == PackageManager.PERMISSION_GRANTED -> {
+                    addRegistrationId()
+                }
+
+                shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS) -> {
+                    viewModel.moveToNotificationPermissionDialog(args.studyId)
+                }
+
+                else -> {
+                    requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                }
+            }
+        } else {
+            addRegistrationId()
+        }
+    }
+
+    private fun addRegistrationId() {
+        viewModel.updateStudyGroup("add", args.studyId)
+        viewModel.addRegistrationIdEvent.observe(
+            viewLifecycleOwner,
+            EventObserver {
+                binding.ivNotification.isSelected = true
+            }
+        )
+    }
+
     private fun setNavigation() {
         moveToBack()
         moveToExitDialog()
+        moveToNotificationPermissionDialog()
     }
 
     private fun moveToBack() {
@@ -229,6 +307,16 @@ class MessageFragment : Fragment() {
             viewLifecycleOwner,
             EventObserver {
                 val action = MessageFragmentDirections.actionMessageToExitDialog(it)
+                findNavController().navigate(action)
+            }
+        )
+    }
+
+    private fun moveToNotificationPermissionDialog() {
+        viewModel.moveToNotificationPermissionDialogEvent.observe(
+            viewLifecycleOwner,
+            EventObserver {
+                val action = MessageFragmentDirections.actionGlobalToNotificationPermissionDialog(it)
                 findNavController().navigate(action)
             }
         )

--- a/app/src/main/java/com/sesac/developer_study_platform/ui/message/MessageFragment.kt
+++ b/app/src/main/java/com/sesac/developer_study_platform/ui/message/MessageFragment.kt
@@ -149,7 +149,7 @@ class MessageFragment : Fragment() {
     }
 
     private fun sendImage(uriList: List<Uri>, timestamp: Long) {
-        viewModel.sendImage(args.studyId, uriList, timestamp)
+        viewModel.sendImage(args.studyId, uriList, timestamp, getString(R.string.chat_room_last_message_image))
         viewModel.addMessageEvent.observe(
             viewLifecycleOwner,
             EventObserver {

--- a/app/src/main/java/com/sesac/developer_study_platform/ui/message/MessageViewModel.kt
+++ b/app/src/main/java/com/sesac/developer_study_platform/ui/message/MessageViewModel.kt
@@ -53,6 +53,10 @@ class MessageViewModel(private val fcmTokenRepository: FcmTokenRepository) : Vie
     private val _moveToExitDialogEvent: MutableLiveData<Event<String>> = MutableLiveData()
     val moveToExitDialogEvent: LiveData<Event<String>> = _moveToExitDialogEvent
 
+    private val _moveToNotificationPermissionDialogEvent: MutableLiveData<Event<String>> = MutableLiveData()
+    val moveToNotificationPermissionDialogEvent: LiveData<Event<String>> =
+        _moveToNotificationPermissionDialogEvent
+
     private val _isAdminEvent: MutableLiveData<Event<Boolean>> = MutableLiveData(Event(false))
     val isAdminEvent: LiveData<Event<Boolean>> = _isAdminEvent
 
@@ -410,6 +414,10 @@ class MessageViewModel(private val fcmTokenRepository: FcmTokenRepository) : Vie
 
     fun moveToExitDialog(sid: String) {
         _moveToExitDialogEvent.value = Event(sid)
+    }
+
+    fun moveToNotificationPermissionDialog(sid: String) {
+        _moveToNotificationPermissionDialogEvent.value = Event(sid)
     }
 
     companion object {

--- a/app/src/main/java/com/sesac/developer_study_platform/ui/message/MessageViewModel.kt
+++ b/app/src/main/java/com/sesac/developer_study_platform/ui/message/MessageViewModel.kt
@@ -290,9 +290,9 @@ class MessageViewModel(private val fcmTokenRepository: FcmTokenRepository) : Vie
             kotlin.runCatching {
                 val notificationKey = getNotificationKey(sid)
                 if (!notificationKey.isNullOrEmpty()) {
-                    fcmRepository.sendNotification(
-                        FcmMessage(FcmMessageData(notificationKey, fcmMessageContent))
-                    )
+                    val fcmMessageData =
+                        FcmMessageData(notificationKey, fcmMessageContent, mapOf("direct_boot_ok" to true))
+                    fcmRepository.sendNotification(FcmMessage(fcmMessageData))
                 }
             }.onFailure {
                 Log.e("MessageViewModel-sendNotification", it.message ?: "error occurred.")

--- a/app/src/main/res/drawable/ic_notification.xml
+++ b/app/src/main/res/drawable/ic_notification.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M160,760v-80h80v-280q0,-83 50,-147.5T420,168v-28q0,-25 17.5,-42.5T480,80q25,0 42.5,17.5T540,140v28q80,20 130,84.5T720,400v280h80v80L160,760ZM480,460ZM480,880q-33,0 -56.5,-23.5T400,800h160q0,33 -23.5,56.5T480,880ZM320,680h320v-280q0,-66 -47,-113t-113,-47q-66,0 -113,47t-47,113v280Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_notification_off.xml
+++ b/app/src/main/res/drawable/ic_notification_off.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M160,760v-80h80v-280q0,-33 8.5,-65t25.5,-61l60,60q-7,16 -10.5,32.5T320,400v280h248L56,168l56,-56 736,736 -56,56 -146,-144L160,760ZM720,606 L640,526v-126q0,-66 -47,-113t-113,-47q-26,0 -50,8t-44,24l-58,-58q20,-16 43,-28t49,-18v-28q0,-25 17.5,-42.5T480,80q25,0 42.5,17.5T540,140v28q80,20 130,84.5T720,400v206ZM444,556ZM480,880q-33,0 -56.5,-23.5T400,800h160q0,33 -23.5,56.5T480,880ZM513,399Z" />
+</vector>

--- a/app/src/main/res/drawable/selector_notification.xml
+++ b/app/src/main/res/drawable/selector_notification.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_notification_off" android:state_selected="false" />
+    <item android:drawable="@drawable/ic_notification" />
+</selector>

--- a/app/src/main/res/layout/fragment_message.xml
+++ b/app/src/main/res/layout/fragment_message.xml
@@ -134,6 +134,17 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
+            <ImageView
+                android:id="@+id/iv_notification"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/space_median"
+                android:layout_marginEnd="@dimen/space_median"
+                android:contentDescription="@string/message_menu_notification_description"
+                android:src="@drawable/selector_notification"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/rv_member_list"
                 android:layout_width="0dp"

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -21,6 +21,12 @@
         android:id="@+id/action_global_to_notification_permission_dialog"
         app:destination="@id/dest_notification_permission_dialog" />
 
+    <activity
+        android:id="@+id/dest_main"
+        android:name="com.sesac.developer_study_platform.ui.main.MainActivity"
+        android:label="activity_main"
+        tools:layout="@layout/activity_main" />
+
     <fragment
         android:id="@+id/dest_login"
         android:name="com.sesac.developer_study_platform.ui.login.LoginFragment"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -139,6 +139,7 @@
     <string name="message_left_study_member">스터디 멤버가 퇴장하였습니다.</string>
     <string name="message_menu_member">대화상대</string>
     <string name="message_menu_exit_description">채팅방 나가기 아이콘</string>
+    <string name="message_menu_notification_description">알림 설정</string>
 
     <string name="my_page_icon_bookmark_description">북마크 모양의 아이콘</string>
     <string name="my_page_logout">로그아웃</string>


### PR DESCRIPTION
## 작업 내용
- [x] 채팅방 별로 알림 설정
- [x] 알림 메시지 전송, 수신
- [x] 알림 메시지 클릭 시 해당 채팅방으로 이동
- [x] fcm 서버 및 데이터베이스에서 notification key, 사용자 디바이스 토큰 삭제
- [x] 채팅 화면, 스터디 참여하기 다이얼로그, 알림 권한 다이얼로그 알림 권한 요청 구현

## 체크리스트
- [x] Assignees 설정
- [x] Labels 설정
- [x] Projects 설정
- [x] Milestone 설정

## 기타
- 알림 메시지 클릭 시 스플래시와 충돌이 나는 것 같아서 우선 `startSplash()` 함수는 주석 처리 해놓았습니다🫠
- 혹시 이해가 안가신다면 [알림 권한 요청 로직](https://github.com/android-team-02/developer-study-platform/wiki/FCM-%EA%B7%B8%EB%A3%B9-%EC%B1%84%ED%8C%85-%EC%95%8C%EB%A6%BC) 참고해주세요🫨